### PR TITLE
Abstract out creation of transitive object libraries

### DIFF
--- a/examples/blinky-multiboard/src/board/nucleo-l412/CMakeLists.txt
+++ b/examples/blinky-multiboard/src/board/nucleo-l412/CMakeLists.txt
@@ -1,5 +1,8 @@
 generate_stm32cube(stm32l412 LL_DRIVERS gpio utils pwr rcc)
 
+# NOTE: object libraries must be used when creating a library that uses
+# STM32Cube due to the way the linker handles weak symbols when linking static
+# libraries
 add_library(board_stm32l412 OBJECT board.c)
 target_include_directories(board_stm32l412 PUBLIC ../common/include)
 target_link_libraries(
@@ -7,9 +10,8 @@ target_link_libraries(
   PUBLIC stm32::stm32l412_cmsis stm32::stm32l412_ll_gpio
          stm32::stm32l412_ll_utils stm32::stm32l412_ll_pwr
          stm32::stm32l412_ll_rcc)
-# create interface library to allow transitive OBJECT library dependencies
-add_library(_board_stm32l412 INTERFACE)
-target_link_libraries(
-  _board_stm32l412 INTERFACE board_stm32l412 $<TARGET_OBJECTS:board_stm32l412>)
-# create alias for namespacing
-add_library(board::stm32l412 ALIAS _board_stm32l412)
+
+add_library(board::stm32l412 ALIAS board_stm32l412)
+# NOTE: object libraries are not transitive. if linking this library to another
+# object library, use this instead:
+# add_transitive_object_library(board::stm32l412 board_stm32l412)

--- a/examples/blinky-multiboard/src/board/nucleo-l476/CMakeLists.txt
+++ b/examples/blinky-multiboard/src/board/nucleo-l476/CMakeLists.txt
@@ -1,5 +1,8 @@
 generate_stm32cube(stm32l476 LL_DRIVERS gpio utils pwr rcc)
 
+# NOTE: object libraries must be used when creating a library that uses
+# STM32Cube due to the way the linker handles weak symbols when linking static
+# libraries
 add_library(board_stm32l476 OBJECT board.c)
 target_include_directories(board_stm32l476 PUBLIC ../common/include)
 target_link_libraries(
@@ -7,9 +10,8 @@ target_link_libraries(
   PUBLIC stm32::stm32l476_cmsis stm32::stm32l476_ll_gpio
          stm32::stm32l476_ll_utils stm32::stm32l476_ll_pwr
          stm32::stm32l476_ll_rcc)
-# create interface library to allow transitive OBJECT library dependencies
-add_library(_board_stm32l476 INTERFACE)
-target_link_libraries(
-  _board_stm32l476 INTERFACE board_stm32l476 $<TARGET_OBJECTS:board_stm32l476>)
-# create alias for namespacing
-add_library(board::stm32l476 ALIAS _board_stm32l476)
+
+add_library(board::stm32l476 ALIAS board_stm32l476)
+# NOTE: object libraries are not transitive. if linking this library to another
+# object library, use this instead:
+# add_transitive_object_library(board::stm32l476 board_stm32l476)


### PR DESCRIPTION
Creates a function to prevent the user from having to think about how to create a transitive object library.