### PR TITLE
Use custom action for arm toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,44 +13,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: |
-          pip install cmake-format
+        run: sudo apt install -y cmake-format
 
       - name: Lint
-        run: |
-          find . \( -name CMakeLists.txt -o -name *.cmake \) -exec cmake-format --check {} +
+        run: find . \( -name CMakeLists.txt -o -name *.cmake \) -exec cmake-format --check {} +
 
   compile:
     name: Compile
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          mkdir -p .deps
-          pip install cmake
-          wget -q https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz -P .deps
-          tar -xf .deps/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz -C .deps
-          echo "$(pwd)/.deps/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin" >> $GITHUB_PATH
+      - name: Install ARM toolchain
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+
+      - name: Install CMake
+        run: sudo apt install -y cmake
 
       - name: Checkout STM32CubeL4
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: STMicroelectronics/STM32CubeL4
           submodules: true
           path: ./STM32CubeL4
 
-      - name: Compile LL
+      - name: Compile blinky-ll
         run: cmake -S examples/blinky-ll --preset debug -DSTM32CUBEL4_PATH=$(pwd)/STM32CubeL4 && cmake --build examples/blinky-ll/build
 
-      - name: Compile HAL
+      - name: Compile blinky-hal
         run: cmake -S examples/blinky-hal --preset debug -DSTM32CUBEL4_PATH=$(pwd)/STM32CubeL4 && cmake --build examples/blinky-ll/build
 
-      - name: Compile Multiboard
+      - name: Compile blinky-multiboard
         run: cmake -S examples/blinky-multiboard --preset debug -DSTM32CUBEL4_PATH=$(pwd)/STM32CubeL4 && cmake --build examples/blinky-ll/build
     

--- a/examples/blinky-multiboard/CMakePresets.json
+++ b/examples/blinky-multiboard/CMakePresets.json
@@ -17,18 +17,13 @@
                 "STM32CUBEL4_PATH": "${sourceDir}/STM32CubeL4",
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "1"
-            },
-            "condition": {
-                "type": "notEquals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
             }
         },
         {
             "name": "debug-windows",
             "inherits": "debug",
-            "displayName": "Debug",
-            "description": "Debug build preset",
+            "displayName": "Debug (Windows)",
+            "description": "Windows debug build preset",
             "generator": "MinGW Makefiles",
             "condition": {
                 "type": "equals",
@@ -43,18 +38,13 @@
             "description": "Release build preset",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
-            },
-            "condition": {
-                "type": "notEquals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
             }
         },
         {
             "name": "release-windows",
             "inherits": "debug-windows",
-            "displayName": "Release",
-            "description": "Release build preset",
+            "displayName": "Release (Windows)",
+            "description": "Windows release build preset",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }


### PR DESCRIPTION
Use a custom ARM toolchain action to use latest version of ARM toolchain and cache the toolchain.